### PR TITLE
Fix notification for candidate

### DIFF
--- a/tstsite/inc/customizer.php
+++ b/tstsite/inc/customizer.php
@@ -425,7 +425,7 @@ function ajax_approve_candidate() {
         if($doer->ID === $candidate->ID) {
             continue;
         }
-        UserNotifModel::instance()->push_notif($candidate->ID, UserNotifModel::$TYPE_CHOOSE_OTHER_TASKDOER, ['task_id' => $task_id, 'from_user_id' => $doer->ID]);
+        UserNotifModel::instance()->push_notif($candidate->ID, UserNotifModel::$TYPE_CHOOSE_OTHER_TASKDOER, ['task_id' => $task_id, 'from_user_id' => $task_author->ID]);
     }
     
     wp_die(json_encode(array(


### PR DESCRIPTION
The error in the code has been fixed where the notification contained the wrong user (the task doer chosen by the author, not the author of the task).

Исправлена ошибка в коде, где уведомление содержало неверного пользователя (исполнителя выбранного автором, а не самого автора задачи).